### PR TITLE
Externalize site-specific settings

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  ORIGIN: process.env.ORIGIN || "https://viaadnexusnus.wixsite.com",
+  SITE_PATH: process.env.SITE_PATH || "/viaadnexus",
+  PUBLIC_HOST: process.env.PUBLIC_HOST || "https://www.viaadnexus.top",
+  PUBLIC_BASE: process.env.PUBLIC_BASE || "",
+  PUBLIC_ORIGIN: process.env.PUBLIC_ORIGIN || process.env.PUBLIC_HOST || "https://www.viaadnexus.top",
+  FAVICON_URL: process.env.FAVICON_URL || "/assets/viaadnexus_logo.png",
+  OG_IMAGE_URL: process.env.OG_IMAGE_URL || process.env.FAVICON_URL || "/assets/viaadnexus_logo.png",
+  LOGO_ALT_NAMES: (process.env.LOGO_ALT_NAMES ? process.env.LOGO_ALT_NAMES.split(',') : ["viaadnexus_logo.png", "viaadnexus_logo1.png"])
+};


### PR DESCRIPTION
## Summary
- move site-specific constants into new `config.js`
- replace hardcoded paths and hosts in `Proxy/index.js` with config-driven values
- support configurable logo assets and favicon path

## Testing
- `npm test` *(fails: Missing script "test")*
- `node -e "require('./Proxy/index.js')"`

------
https://chatgpt.com/codex/tasks/task_e_68ad20c90a58833090ac7e9798adb619